### PR TITLE
Update Elasticsearch and Kibana states

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,7 +90,7 @@ Vagrant.configure(2) do |config|
   #run highstate
   config.vm.provision :salt do |salt|
     salt.minion_config = 'minion.conf'
-    salt.bootstrap_options = '-U -Z'
+    salt.bootstrap_options = '-U'
     salt.masterless = true
     salt.run_highstate = true
     salt.colorize = true

--- a/elastic-stack/elasticsearch/configure.sls
+++ b/elastic-stack/elasticsearch/configure.sls
@@ -126,3 +126,12 @@ stop_elasticsearch_service:
 start_elasticsearch_service:
   service.running:
     - name: elasticsearch
+
+{% for template in
+   salt.pillar.get('elastic_stack:elasticsearch:index_templates', []) %}
+update_{{ template.name }}_template:
+  elasticsearch.index_template_present:
+    - name: {{ template.name }}
+    - definition: {{ template.definition | tojson }}
+    - check_definition: True
+{% endfor %}

--- a/elastic-stack/kibana/plugins.sls
+++ b/elastic-stack/kibana/plugins.sls
@@ -3,7 +3,7 @@
 include:
   - .service
 
-{% for plugin in salt.pillar.get('kibana:plugins', {}) %}
+{% for plugin in salt.pillar.get('elastic_stack:kibana:plugins', {}) %}
 install_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/kibana/bin/kibana-plugin install {{ plugin.get('location', plugin.name) }}

--- a/elastic-stack/map.jinja
+++ b/elastic-stack/map.jinja
@@ -17,4 +17,4 @@
     'RedHat': {
         'pkg_repo_suffix': 'centos',
     },
-}, grain='os_family', merge=salt['pillar.get']('elasticsearch:lookup'), base='default') %}
+}, grain='os_family', merge=salt['pillar.get']('elastic_stack:overrides'), base='default') %}

--- a/elastic-stack/repository.sls
+++ b/elastic-stack/repository.sls
@@ -18,7 +18,7 @@ configure_elastic_stack_package_repo:
     - gpgkey: {{ elastic_stack.gpg_key }}
     - refresh_db: True
     {% elif os_family == 'RedHat' %}
-    - name: {{ name }}
+    - name: elastic_stack
     - baseurl: {{ elastic_stack.pkg_repo_url }}/yum
     - gpgcheck: 1
     - enabled: 1

--- a/elastic-stack/repository.sls
+++ b/elastic-stack/repository.sls
@@ -5,7 +5,7 @@
 {% if os_family == 'RedHat' %}
 install_elastic_stack_gpg_key:
   cmd.run:
-    - name: rpm --import {{ elastic_stack.gpg-key }}
+    - name: rpm --import {{ elastic_stack.gpg_key }}
     - require_in:
         - pkgrepo: configure_elastic_stack_package_repo
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -17,6 +17,27 @@ elastic_stack:
             aws:
               region: us-east-1
       - name: repository-s3
+    index_templates:
+      - name: logstash
+        definition:
+          template: logstash-*
+          settings:
+            index:
+              refresh_interval: 5s
+              number_of_shards: 5
+              number_of_replicas: 1
+          mappings:
+            fluentd:
+              dynamic_templates:
+                - strings:
+                    match_mapping_type: string
+                    mapping:
+                      type: string
+                      fields:
+                        raw:
+                          type: string
+                          index: not_analyzed
+                          ignore_above: 256
   beats:
     metricbeat:
       config:


### PR DESCRIPTION
Make various updates for Kibana and Elasticsearch states to correct them and to get ready for our ELK upgrade, which will make use of this formula for both Elasticsearch and Kibana.

See https://github.com/mitodl/salt-ops/issues/761 and https://github.com/mitodl/salt-ops/pull/779