### PR TITLE
Remove write of plugin 'config' to elasticsearch.yml

### DIFF
--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -10,14 +10,4 @@ install_{{ plugin.name }}_plugin:
     - unless: "[ $(/usr/share/elasticsearch/bin/elasticsearch-plugin list | grep {{ plugin.name }} | wc -l) -eq 1 ]"
     - watch_in:
         - service: elasticsearch_service
-
-{% if plugin.get('config') %}
-plugin_configuration_for_{{ plugin.name }}:
-  file.append:
-    - name: /etc/elasticsearch/elasticsearch.yml
-    - text: |
-        {{ plugin.config | yaml(False) | indent(8) }}
-    - watch_in:
-        - service: elasticsearch_service
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
Remove the for loop that writes plugin configuration properties to
elasticsearch.yml.

As of ES version 6.7, these produce IllegalArgumentExceptions in the
single case where we once used it, for the ec2-discovery plugin.

I'd be interested in doing a followup PR to create individual states for discovery and snapshotting. (`elastic-stack.elasticsearch.ec2-discovery` and `s3-snapshot`). The snapshot one, at least, deserves some effort to set up the configuration described in http://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.elasticsearch.html, which I don't think we have yet.  So in order to get https://github.com/mitodl/salt-ops/issues/761 done maybe those can follow later.
