### PR TITLE
Ensure writability of kibana.log

### DIFF
--- a/elastic-stack/kibana/configure.sls
+++ b/elastic-stack/kibana/configure.sls
@@ -8,6 +8,13 @@ create_kibana_directory:
     - name: /etc/kibana
     - makedirs: True
 
+ensure_writability_of_kibana_log:
+  file.managed:
+    - name: /var/log/kibana.log
+    - user: kibana
+    - group: kibana
+    - mode: 0640
+
 configure_kibana:
   file.managed:
     - name: /etc/kibana/kibana.yml


### PR DESCRIPTION
Mainly relevant for a new installation, ensure that `/var/log/kibana.log` is writable by the `kibana` user.

Before this, Kibana was installed but could not start because it could not open its log.

I've tested this usage of `file.managed` without a contents property in a demo Salt VM. If the file already exists it does not get clobbered.
