### PR TITLE
Add cronjob to clean up old logs

### DIFF
--- a/elastic-stack/elasticsearch/cron.sls
+++ b/elastic-stack/elasticsearch/cron.sls
@@ -1,0 +1,7 @@
+clean_old_logs_cronjob:
+  cron.present:
+    - identifier: clean_old_logs
+    - name: /usr/bin/find /usr/share/elasticsearch/logs -type f -name '*.gz' -mtime +30 -exec rm {} \; > /var/log/clean-es-logs.log 2>&1
+    - user: root
+    - minute: 0
+    - hour: 0

--- a/elastic-stack/elasticsearch/init.sls
+++ b/elastic-stack/elasticsearch/init.sls
@@ -2,3 +2,4 @@ include:
   - .install
   - .configure
   - .plugins
+  - .cron


### PR DESCRIPTION
Add a cronjob to delete old logs in `/usr/share/elasticsearch/logs` older than 30 days.