### PR TITLE
Make all Elastic Stack products have same version

### DIFF
--- a/elastic-stack/beats/map.jinja
+++ b/elastic-stack/beats/map.jinja
@@ -1,11 +1,13 @@
 {% set elastic_beats = salt.pillar.get('elastic_stack:beats', {}) %}
+{% set version = salt.pillar.get('elastic_stack:version') %}
+
 {% set beats = {
     'pkgs': [],
     'services': [],
     'agents': {}
 } %}
 {% for beat, settings in elastic_beats.items() %}
-{% do beats['pkgs'].append(beat) %}
+{% do beats['pkgs'].append({beat: version}) %}
 {% do beats['services'].append(beat) %}
 {% do beats['agents'].update(
     {

--- a/elastic-stack/elasticsearch/install.sls
+++ b/elastic-stack/elasticsearch/install.sls
@@ -1,5 +1,6 @@
 {% from "elastic-stack/elasticsearch/map.jinja" import elasticsearch with context %}
 {% set osfullname = salt.grains.get('osfullname') %}
+{% set version = salt.pillar.get('elastic_stack:version') %}
 
 include:
     - elastic-stack.repository
@@ -11,7 +12,8 @@ install_pkg_dependencies:
 
 install_elasticsearch:
   pkg.installed:
-    - pkgs: {{ elasticsearch.pkgs }}
+    - name: elasticsearch
+    - version: {{ version }}
     - refresh: True
     - skip_verify: {{ not elasticsearch.get('verify_package', True) }}
     - require:

--- a/elastic-stack/elasticsearch/map.jinja
+++ b/elastic-stack/elasticsearch/map.jinja
@@ -1,11 +1,6 @@
-{% set version = salt.pillar.get('elasticsearch:version', '6.x') %}
 {% set elasticsearch = salt.grains.filter_by({
     'default': {
-        'version': version,
         'pkg_deps': [],
-        'pkgs': [
-            'elasticsearch'
-        ],
         'service': 'elasticsearch',
         'configuration_settings': {
             'node.data': true,

--- a/elastic-stack/kibana/install.sls
+++ b/elastic-stack/kibana/install.sls
@@ -1,11 +1,13 @@
 {% from "elastic-stack/kibana/map.jinja" import kibana with context %}
+{% set version = salt.pillar.get('elastic_stack:version') %}
 
 include:
   - elastic-stack.repository
 
 install_kibana:
   pkg.installed:
-    - pkgs: {{ kibana.pkgs }}
+    - name: kibana
+    - version: {{ version }}
     - reload_modules: True
     - update: True
     - require:

--- a/elastic-stack/kibana/map.jinja
+++ b/elastic-stack/kibana/map.jinja
@@ -1,8 +1,5 @@
 {% set kibana = salt.grains.filter_by({
     'default': {
-        'pkgs': [
-            'kibana'
-        ],
         'config': {
             'elasticsearch.url': 'http://localhost:9200',
             'server.host': '127.0.0.1',

--- a/elastic-stack/map.jinja
+++ b/elastic-stack/map.jinja
@@ -1,4 +1,6 @@
-{% set version = salt.pillar.get('elastic_stack:version', '6.x') %}
+{% set version = salt.pillar.get('elastic_stack:version') %}
+{% set maj_version = elastic_stack.version.split('.')[0] %}
+
 {% set elastic_stack = salt['grains.filter_by']({
     'default': {
         'version': version,
@@ -8,7 +10,7 @@
             'gateway.recover_after_time': '5m',
         },
         'gpg_key': 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
-        'pkg_repo_url': 'https://artifacts.elastic.co/packages/{0}'.format(version)
+        'pkg_repo_url': 'https://artifacts.elastic.co/packages/{0}.x'.format(maj_version)
     },
     'Debian': {
         'pkg_repo_suffix': 'debian',


### PR DESCRIPTION
Use one variable, `elastic_stack:version` to ensure that all ES products (e.g. Kibana + Elasticsearch) have the same version.

 