### PR TITLE
Fix elasticsearch plugin upgrade

### DIFF
--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -10,14 +10,14 @@ remove_{{ plugin.name }}_plugin:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ plugin.get('location', plugin.name) }}
     - onchanges:
       - pkg: install_elasticsearch
-    - require_in:
-      - cmd: install_{{ plugin.name }}_plugin
 
 install_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin install -b {{ plugin.get('location', plugin.name) }}
     - onchanges:
       - pkg: install_elasticsearch
+    - require:
+        - cmd: remove_{{ plugin.name }}_plugin
     - watch_in:
         - service: elasticsearch_service
 {% endfor %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -5,15 +5,19 @@ include:
   - .install
 
 {% for plugin in salt.pillar.get('elastic_stack:elasticsearch:plugins', []) %}
-install_{{ plugin.name }}_plugin:
+remove_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ plugin.get('location', plugin.name) }}
-    - onchanges: install_elasticsearch
-    - watch_in:
-      - service: elasticsearch_service
+    - onchanges:
+      - pkg: install_elasticsearch
+    - require_in:
+      - cmd: install_{{ plugin.name }}_plugin
+
+install_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin install -b {{ plugin.get('location', plugin.name) }}
-    - onchanges: install_elasticsearch
+    - onchanges:
+      - pkg: install_elasticsearch
     - watch_in:
         - service: elasticsearch_service
 {% endfor %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -1,13 +1,16 @@
 {% from "elastic-stack/elasticsearch/map.jinja" import elasticsearch with context %}
+{% set commands = {'install': 'install -b', 'remove': 'remove'} %}
 
 include:
   - .service
 
 {% for plugin in salt.pillar.get('elastic_stack:elasticsearch:plugins', []) %}
-install_{{ plugin.name }}_plugin:
+{% for command in commands %}
+{{ command }}_{{ plugin.name }}_plugin:
   cmd.run:
-    - name: /usr/share/elasticsearch/bin/elasticsearch-plugin install -b {{ plugin.get('location', plugin.name) }}
+    - name: /usr/share/elasticsearch/bin/elasticsearch-plugin {{ commands[command] }} {{ plugin.get('location', plugin.name) }}
     - unless: "[ $(/usr/share/elasticsearch/bin/elasticsearch-plugin list | grep {{ plugin.name }} | wc -l) -eq 1 ]"
     - watch_in:
         - service: elasticsearch_service
+{% endfor %}
 {% endfor %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -1,15 +1,19 @@
 {% from "elastic-stack/elasticsearch/map.jinja" import elasticsearch with context %}
-{% set commands = {'install': 'install -b', 'remove': 'remove'} %}
 
 include:
   - .service
+  - .install
 
 {% for plugin in salt.pillar.get('elastic_stack:elasticsearch:plugins', []) %}
-{% for command in commands %}
-{{ command }}_{{ plugin.name }}_plugin:
+install_{{ plugin.name }}_plugin:
   cmd.run:
-    - name: /usr/share/elasticsearch/bin/elasticsearch-plugin {{ commands[command] }} {{ plugin.get('location', plugin.name) }}
+    - name: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ plugin.get('location', plugin.name) }}
+    - onchanges: install_elasticsearch
+    - watch_in:
+      - service: elasticsearch_service
+  cmd.run:
+    - name: /usr/share/elasticsearch/bin/elasticsearch-plugin install -b {{ plugin.get('location', plugin.name) }}
+    - onchanges: install_elasticsearch
     - watch_in:
         - service: elasticsearch_service
-{% endfor %}
 {% endfor %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -9,7 +9,6 @@ include:
 {{ command }}_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin {{ commands[command] }} {{ plugin.get('location', plugin.name) }}
-    - unless: "[ $(/usr/share/elasticsearch/bin/elasticsearch-plugin list | grep {{ plugin.name }} | wc -l) -eq 1 ]"
     - watch_in:
         - service: elasticsearch_service
 {% endfor %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -8,6 +8,8 @@ include:
 remove_{{ plugin.name }}_plugin:
   cmd.run:
     - name: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ plugin.get('location', plugin.name) }}
+    - onlyif:
+        - test -e /usr/share/elasticsearch/plugins/{{ plugin.name }}/{{ plugin.name }}*.jar
     - onchanges:
       - pkg: install_elasticsearch
 


### PR DESCRIPTION
Remove the plugin before installing it, to allow upgrades to work.

See https://www.elastic.co/guide/en/elasticsearch/plugins/6.8/listing-removing-updating.html#_updating_plugins

Is it correct that we rarely run this state; that it would only run during a highstate or when executed specifically? If so, then I assume that the plugin removal it doesn't cause any unnecessary work to be performed. The way prior to this change was to skip upgrading the plugin if it was already installed, which causes upgrades to fail when Elasticsearch is restarted 
with an old version of the plugin that's incompatible with the new version of Elasticsearch.
