### PR TITLE
Ensure existence of systemd fragment directory

### DIFF
--- a/elastic-stack/elasticsearch/configure.sls
+++ b/elastic-stack/elasticsearch/configure.sls
@@ -93,6 +93,7 @@ update_sysctl_file_descriptor_limit:
 update_elasticsearch_systemd_file_descriptor_limit:
   file.managed:
     - name: /etc/systemd/system/elasticsearch.service.d/fdlimit.conf
+    - makedirs: True
     - contents: |
         [Service]
         LimitNOFILE={{ elasticsearch.fd_limit }}


### PR DESCRIPTION
Ensure that `/etc/systemd/system/elasticsearch.service.d` exists before trying to place `fdlimit.conf` there.