### PR TITLE
Add alias arg to elastalert-create-index invocation

### DIFF
--- a/elastic-stack/elastalert/configure.sls
+++ b/elastic-stack/elastalert/configure.sls
@@ -59,4 +59,5 @@ generate_elastalert_status_index:
         --url-prefix {{ elastalert.settings.get("es_url_prefix", "''") }}
         --index {{ elastalert.settings.writeback_index }}
         --old-index {{ elastalert.settings.get("old_writeback_index", "''") }}
+        --alias {{ elastalert.settings.get("alias", 'elastalert_alerts')}}
 {% endif %}


### PR DESCRIPTION
In `generate_elastalert_status_index` in `configure.sls`, add the `--alias`argument to the invocation of `elastalert-create-index`. If this is not provided, the utility waits for user input and the state fails.

The default value of "elastalert_alerts" will be provided if `elastalert.settings.alias` is not provided in the pillar. This is reported as the default value by the utility's help.