### PR TITLE
Upgraded java and minor fixes

### DIFF
--- a/elastic-stack/elasticsearch/configure.sls
+++ b/elastic-stack/elasticsearch/configure.sls
@@ -44,8 +44,8 @@ update_elasticsearch_heap_size:
 update_elasticsearch_java_home:
   file.replace:
     - name: {{ elasticsearch.env_file }}
-    - pattern: '^#JAVA_HOME='
-    - repl: 'JAVA_HOME="{{ elasticsearch.java_home }}"'
+    - pattern: '^#ES_JAVA_HOME='
+    - repl: 'ES_JAVA_HOME="{{ elasticsearch.java_home }}"'
     - append_if_not_found: True
     - onchanges_in:
         - service: elasticsearch_service

--- a/elastic-stack/elasticsearch/map.jinja
+++ b/elastic-stack/elasticsearch/map.jinja
@@ -12,20 +12,20 @@
         'log_folder': '/usr/share/elasticsearch/logs',
         'conf_folder': '/etc/elasticsearch/',
         'conf_file': '/etc/elasticsearch/elasticsearch.conf',
-        'java_home': '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
+        'java_home': '/usr/lib/jvm/java-11-openjdk-amd64'
     },
     'Debian':{
         'pkg_deps': [
-            'openjdk-8-jre-headless',
+            'openjdk-11-jre-headless',
             'apt-transport-https'
         ],
         'env_file': '/etc/default/elasticsearch'
     },
     'RedHat': {
         'pkg_deps': [
-            'java-1.8.0-openjdk-headless'
+            'java-11-openjdk-headless'
         ],
         'env_file': '/etc/sysconfig/elasticsearch',
-        'java_home': '/usr/lib/jvm/jre-1.8.0-openjdk'
+        'java_home': '/usr/lib/jvm/jre-11-openjdk'
     },
 }, grain='os_family', merge=salt.pillar.get('elastic_stack:elasticsearch'), base='default') %}

--- a/elastic-stack/elasticsearch/plugins.sls
+++ b/elastic-stack/elasticsearch/plugins.sls
@@ -22,4 +22,8 @@ install_{{ plugin.name }}_plugin:
         - cmd: remove_{{ plugin.name }}_plugin
     - watch_in:
         - service: elasticsearch_service
+
+set_permissions_on_{{plugin.name}}_plugin:
+  cmd.run:
+    - name: chgrp -R elasticsearch /etc/elasticsearch/{{ plugin.name }}
 {% endfor %}


### PR DESCRIPTION
Made the following changes:
- Upgraded java from 8 to 11 based on warning when running ES service
- Changed `JAVA_HOME` to `ES_JAVA_HOME` as the former is no longer in the file
- Added a command to recursively change group ownership of plugin dir as service was failing to start 